### PR TITLE
Redirect authenticated users from homepage to /dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,21 @@
-import { clerkMiddleware } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
 
-export default clerkMiddleware()
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
+const isHomepage = createRouteMatcher(['/'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect()
+  }
+
+  if (isHomepage(req)) {
+    const { userId } = await auth()
+    if (userId) {
+      return NextResponse.redirect(new URL('/dashboard', req.url))
+    }
+  }
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
If a logged-in user visits `/`, the middleware now detects their session via Clerk and issues a redirect to `/dashboard`. Also wires up the `createRouteMatcher`-based protection for all `/dashboard` routes per the routing.md spec.